### PR TITLE
Add padded resize and grayscale contrast option

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
       <div class="oui-bubble">
         <p class="oui-overlay-bubble-item">이미지 URL을 입력하세요</p>
         <input type="text" id="image-url" class="oui-text-field" />
+        <label class="oui-checkbox">
+          <input type="checkbox" id="enable-grayscale-contrast">
+          <span>흑백 + 대비 강화 적용</span>
+        </label>
         <button id="decode-btn" class="oui-button">Decode</button>
       </div>
       <div id="result" class="oui-bubble"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -16,8 +16,15 @@ async function loadModel() {
   }
 }
 
+function getPreprocessOptions() {
+  const grayscaleCheckbox = document.getElementById('enable-grayscale-contrast');
+  return {
+    applyGrayscaleContrast: grayscaleCheckbox ? grayscaleCheckbox.checked : false,
+  };
+}
+
 function preprocessImage(img) {
-  const canvas = resizeImage(img);
+  const canvas = resizeImage(img, getPreprocessOptions());
   let tensor = tf.browser.fromPixels(canvas, 1);
   tensor = tensor.expandDims(0).toFloat().div(255.0);
   return tensor;

--- a/js/resize_image.js
+++ b/js/resize_image.js
@@ -1,8 +1,24 @@
-function resizeImage(img) {
+function resizeImage(img, options = {}) {
+  const targetWidth = 200;
+  const targetHeight = 50;
   const canvas = document.createElement('canvas');
-  canvas.width = 200;
-  canvas.height = 50;
+  canvas.width = targetWidth;
+  canvas.height = targetHeight;
+
   const ctx = canvas.getContext('2d');
-  ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, targetWidth, targetHeight);
+
+  const scale = Math.min(targetWidth / img.width, targetHeight / img.height);
+  const drawnWidth = Math.round(img.width * scale);
+  const drawnHeight = Math.round(img.height * scale);
+  const offsetX = Math.round((targetWidth - drawnWidth) / 2);
+  const offsetY = Math.round((targetHeight - drawnHeight) / 2);
+
+  if (options.applyGrayscaleContrast) {
+    ctx.filter = 'grayscale(100%) contrast(150%)';
+  }
+
+  ctx.drawImage(img, offsetX, offsetY, drawnWidth, drawnHeight);
   return canvas;
 }


### PR DESCRIPTION
## Summary
- resize CAPTCHA images with centered padding before decoding
- add optional grayscale and contrast preprocessing toggle for noise reduction

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69563183c67c8321999075b24daf040b)

## Summary by Sourcery

Add padded resizing and optional grayscale/contrast preprocessing for CAPTCHA images before model inference.

New Features:
- Center-pad and scale images into a fixed 200x50 canvas before model preprocessing.
- Add a user-controlled option to apply grayscale and increased contrast during image preprocessing via a checkbox in the UI.